### PR TITLE
allow start_38

### DIFF
--- a/resources/home/dnanexus/generate_inca_vcf.py
+++ b/resources/home/dnanexus/generate_inca_vcf.py
@@ -136,7 +136,7 @@ def filter_probeset(cleaned_csv, probeset, genome_build) -> pd.DataFrame:
     for origin in probeset:
         if origin in ["99347387", "96527893"]:
             column = "probeset_id"
-        elif origin in ["germline", "somatic"]:
+        elif origin.lower() in ["germline", "somatic"]:
             column = "allele_origin"
         else:
             raise ValueError(f"Invalid argument: '{origin}'. Expected one of: germline, somatic, 99347387, or 96527893.")


### PR DESCRIPTION
changes:

- changed type variable since I was troubleshooting with type() causing problems
- a bit of error handling for float position (TODO more error handling)
- allow for start_38

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_inca_to_vcf/4)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added genome-build aware processing (GRCh37/GRCh38), automatic mapping of CHROM/POS/REF/ALT and origin-based variant classification; header handling used consistently in annotation.

* **Bug Fixes**
  * Stronger validation for POS and empty results (clear error if no variants).
  * Clearer error messages for invalid filter arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->